### PR TITLE
use node script to generate ext-deps with latest unpkg URLs

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,54 @@
+const fs = require('fs').promises
+const https = require('https')
+
+const dedash = str => str.replace(/-[a-z]/gi, m => m.slice(1).toUpperCase())
+const cleanName = pkg => dedash(pkg.match(/^[^@\/]+/)[0])
+
+const error = data => JSON.stringify(data, null, 2)
+
+const get = url => {
+  const parsed = new URL(url)
+  return new Promise((res, rej) =>
+    https
+      .get(parsed, resp => {
+        let data = ''
+        if (resp.statusCode >= 300 && resp.statusCode < 400 && resp.headers.location) {
+          console.log('following redirect', resp.statusCode, parsed.origin + resp.headers.location)
+          return res(get(parsed.origin + resp.headers.location))
+        }
+        resp.on('data', chunk => (data += chunk))
+        resp.on('end', () => res({ data, url }))
+      })
+      .on('error', err => rej(err))
+  )
+}
+
+const buildDeps = deps =>
+  Promise.all(
+    Object.entries(deps).map(async ([pkg, { name, exports = '*' }]) => {
+      const res = await get(`https://unpkg.com/${pkg}?module`).catch(err => {
+        throw error({ pkg, err })
+      })
+      const src = res.url
+      let hasDefault = name || /\bexport\s+default\b/.test(res.data)
+      let line = ''
+      if (exports && exports.length > 0)
+        line = `export ${
+          Array.isArray(exports) ? '{ ' + exports.join(', ') + ' }' : '*'
+        } from '${src}'`
+      if (hasDefault)
+        line += `${line ? '\n' : ''}export { default as ${name || cleanName(pkg)} } from '${src}'`
+      return line + '\n'
+    })
+  ).then(arr => arr.join('\n'))
+
+const pkgJson = require('./package.json') || {}
+const conf = pkgJson.extdeps || {}
+
+Promise.all(
+  Object.entries(conf).map(async ([file, deps]) => {
+    const script = await buildDeps(deps)
+    await fs.writeFile(file, script)
+    console.log(file, 'built!', Object.keys(deps))
+  })
+).then(() => console.log('== BUILD COMPLETE =='))

--- a/js/actions.js
+++ b/js/actions.js
@@ -1,4 +1,3 @@
-// import { SUB } from './ext-deps.js'
 import { setNight } from './styles.js'
 import { BORDERS, FIRST_LOAD_NUM } from './constants.js'
 import { update, state } from './index.js'

--- a/js/ext-deps.js
+++ b/js/ext-deps.js
@@ -1,6 +1,6 @@
-import z from 'https://unpkg.com/zaftig@0.7/dist/zaftig.min.js'
-z.setDebug(true)
-export { z }
-export { default as merge } from 'https://unpkg.com/mergerino@0.4/dist/mergerino.min.js'
-export { default as m } from 'https://unpkg.com/mithril@2.0.0-rc.4/mithril.mjs'
-export { default as stream } from 'https://unpkg.com/meiosis-setup@2/simple-stream'
+export { default as merge } from 'https://unpkg.com/mergerino@0.4.0/dist/mergerino.min.js?module'
+
+export { default as z } from 'https://unpkg.com/zaftig@0.7.3/dist/zaftig.min.js?module'
+
+export { stream, scan } from 'https://unpkg.com/meiosis-setup@2.0.0/simple-stream/index.js?module'
+export { default as simpleStream } from 'https://unpkg.com/meiosis-setup@2.0.0/simple-stream/index.js?module'

--- a/js/ext-deps.js
+++ b/js/ext-deps.js
@@ -1,6 +1,9 @@
+export { default as m } from 'https://unpkg.com/mithril@2.0.0-rc.4/mithril.mjs?module'
+
 export { default as merge } from 'https://unpkg.com/mergerino@0.4.0/dist/mergerino.min.js?module'
 
 export { default as z } from 'https://unpkg.com/zaftig@0.7.3/dist/zaftig.min.js?module'
 
-export { stream, scan } from 'https://unpkg.com/meiosis-setup@2.0.0/simple-stream/index.js?module'
-export { default as simpleStream } from 'https://unpkg.com/meiosis-setup@2.0.0/simple-stream/index.js?module'
+export { default as setupMeiosis } from 'https://unpkg.com/meiosis-setup@2.0.0/mergerino/index.js?module'
+
+export { default as stream } from 'https://unpkg.com/meiosis-setup@2.0.0/simple-stream/index.js?module'

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,4 @@
-import setup from 'https://unpkg.com/meiosis-setup@2/mergerino'
-import { m, merge, stream } from './ext-deps.js'
+import { m, merge, stream, setupMeiosis } from './ext-deps.js'
 import { id, safeParse } from './util.js'
 
 import { BORDERS } from './constants.js'
@@ -36,7 +35,7 @@ const app = {
 export let state
 export let update
 
-setup({ merge, stream, app }).then(({ update: up, states }) => {
+setupMeiosis({ merge, stream, app }).then(({ update: up, states }) => {
   update = up
   states.map(x => (state = x)).map(m.redraw)
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
   "bugs": {
     "url": "https://github.com/fuzetsu/ayy-rmao/issues"
   },
-  "extdeps": {
+  "mdeps": {
     "./js/ext-deps.js": {
+      "mithril@2.0.0-rc.4": {
+        "name": "m",
+        "exports": []
+      },
       "mergerino@0.4": {
         "name": "merge",
         "exports": []
@@ -25,12 +29,13 @@
         "name": "z",
         "exports": []
       },
+      "meiosis-setup@2/mergerino": {
+        "exports": [],
+        "name": "setupMeiosis"
+      },
       "meiosis-setup@2/simple-stream": {
-        "name": "simpleStream",
-        "exports": [
-          "stream",
-          "scan"
-        ]
+        "name": "stream",
+        "exports": []
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "ayy-rmao",
+  "version": "1.0.0",
+  "description": "simple media focused reddit client",
+  "main": "js/index.js",
+  "scripts": {
+    "build": "node build.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fuzetsu/ayy-rmao.git"
+  },
+  "author": "Daniel Loomer",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/fuzetsu/ayy-rmao/issues"
+  },
+  "extdeps": {
+    "./js/ext-deps.js": {
+      "mergerino@0.4": {
+        "name": "merge",
+        "exports": []
+      },
+      "zaftig@0.7": {
+        "name": "z",
+        "exports": []
+      },
+      "meiosis-setup@2/simple-stream": {
+        "name": "simpleStream",
+        "exports": [
+          "stream",
+          "scan"
+        ]
+      }
+    }
+  },
+  "homepage": "https://github.com/fuzetsu/ayy-rmao#readme"
+}


### PR DESCRIPTION
Using this method we can get static version specific unpkg URLs that load quickly without redirects. With the ability to quickly update the deps using `npm run build`.

Since this isn't a bundle app source can still be modified and reloaded without building. Build script only needs to be run when we want to update versions of dependencies.